### PR TITLE
Ktodo 2: Expand word limitation of description

### DIFF
--- a/src/components/TaskModificationForm.tsx
+++ b/src/components/TaskModificationForm.tsx
@@ -52,6 +52,7 @@ const TaskModificationForm: FC<TaskEditFormProps> = ({
   formFunctionReturn,
 }) => {
   const { md } = useBreakpoint();
+  const { toast } = useToast();
   const {
     handleSubmit,
     register,
@@ -205,6 +206,9 @@ const TaskModificationForm: FC<TaskEditFormProps> = ({
                       className="h-80"
                     />
                   )}
+                />
+                <ErrorMessage
+                  msg={errors.description?.message?.toString()}
                 />
               </div>
               <div className="relative flex gap-1 pb-4">

--- a/src/components/TaskModificationForm.tsx
+++ b/src/components/TaskModificationForm.tsx
@@ -52,7 +52,6 @@ const TaskModificationForm: FC<TaskEditFormProps> = ({
   formFunctionReturn,
 }) => {
   const { md } = useBreakpoint();
-  const { toast } = useToast();
   const {
     handleSubmit,
     register,

--- a/src/lib/validators/todo.ts
+++ b/src/lib/validators/todo.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 
 export const TodoCreateValidator = z.object({
   title: z.string().min(1).max(100),
-  description: z.string().max(1000).optional(),
+  description: z.string().max(5000).optional(),
   state: z.nativeEnum(State),
   deadline: z.number().int().positive().optional(),
   label: z.array(z.string().max(100)).optional(),
@@ -12,7 +12,7 @@ export const TodoCreateValidator = z.object({
 export const TodoEditValidator = z.object({
   id: z.string().length(24),
   title: z.string().min(1).max(100).optional(),
-  description: z.string().max(1000).nullable().optional(),
+  description: z.string().max(5000).nullable().optional(),
   state: z.nativeEnum(State).optional(),
   deadline: z.number().int().positive().nullable().optional(),
   label: z.array(z.string().max(100)).optional(),

--- a/src/lib/validators/todo.ts
+++ b/src/lib/validators/todo.ts
@@ -1,9 +1,11 @@
 import { State } from "@prisma/client";
 import { z } from "zod";
 
+const MAX_DESCIPTION_LENGTH = 5000;
+
 export const TodoCreateValidator = z.object({
   title: z.string().min(1).max(100),
-  description: z.string().max(5000).optional(),
+  description: z.string().max(MAX_DESCIPTION_LENGTH).optional(),
   state: z.nativeEnum(State),
   deadline: z.number().int().positive().optional(),
   label: z.array(z.string().max(100)).optional(),
@@ -12,7 +14,7 @@ export const TodoCreateValidator = z.object({
 export const TodoEditValidator = z.object({
   id: z.string().length(24),
   title: z.string().min(1).max(100).optional(),
-  description: z.string().max(5000).nullable().optional(),
+  description: z.string().max(MAX_DESCIPTION_LENGTH).nullable().optional(),
   state: z.nativeEnum(State).optional(),
   deadline: z.number().int().positive().nullable().optional(),
   label: z.array(z.string().max(100)).optional(),

--- a/src/lib/validators/todo.ts
+++ b/src/lib/validators/todo.ts
@@ -5,7 +5,7 @@ const MAX_DESCRIPTION_LENGTH = 5000;
 
 export const TodoCreateValidator = z.object({
   title: z.string().min(1).max(100),
-  description: z.string().max(MAX_DESCIPTION_LENGTH).optional(),
+  description: z.string().max(MAX_DESCRIPTION_LENGTH).optional(),
   state: z.nativeEnum(State),
   deadline: z.number().int().positive().optional(),
   label: z.array(z.string().max(100)).optional(),
@@ -14,7 +14,7 @@ export const TodoCreateValidator = z.object({
 export const TodoEditValidator = z.object({
   id: z.string().length(24),
   title: z.string().min(1).max(100).optional(),
-  description: z.string().max(MAX_DESCIPTION_LENGTH).nullable().optional(),
+  description: z.string().max(MAX_DESCRIPTION_LENGTH).nullable().optional(),
   state: z.nativeEnum(State).optional(),
   deadline: z.number().int().positive().nullable().optional(),
   label: z.array(z.string().max(100)).optional(),

--- a/src/lib/validators/todo.ts
+++ b/src/lib/validators/todo.ts
@@ -1,7 +1,7 @@
 import { State } from "@prisma/client";
 import { z } from "zod";
 
-const MAX_DESCIPTION_LENGTH = 5000;
+const MAX_DESCRIPTION_LENGTH = 5000;
 
 export const TodoCreateValidator = z.object({
   title: z.string().min(1).max(100),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Error messages are now displayed for the description field in the task modification form, improving form feedback.

* **Improvements**
  * Increased the maximum allowed length for task descriptions from 1,000 to 5,000 characters when creating or editing tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->